### PR TITLE
Fix: Clean up certain comments without names

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -37,9 +37,9 @@ module ActiveRecordCleanDbStructure
       dump.gsub!(/^ALTER SEQUENCE \w+_id_seq OWNED BY .*;$/, '')
       dump.gsub!(/^ALTER TABLE ONLY \w+ ALTER COLUMN id SET DEFAULT nextval\('\w+_id_seq'::regclass\);$/, '')
       dump.gsub!(/^ALTER TABLE ONLY \w+\s+ADD CONSTRAINT \w+_pkey PRIMARY KEY \(id\);$/, '')
-      dump.gsub!(/^-- Name: [\w_]+ id; Type: DEFAULT$/, '')
+      dump.gsub!(/^-- Name: (\w+\s+)?id; Type: DEFAULT$/, '')
       dump.gsub!(/^-- .*_id_seq; Type: SEQUENCE.*/, '')
-      dump.gsub!(/^-- Name: [\w_]+ \w+_pkey; Type: CONSTRAINT$/, '')
+      dump.gsub!(/^-- Name: (\w+\s+)?\w+_pkey; Type: CONSTRAINT$/, '')
 
       # Remove inherited tables
       inherited_tables_regexp = /-- Name: ([\w_]+); Type: TABLE\n\n[^;]+?INHERITS \([\w_]+\);/m


### PR DESCRIPTION
I have lots of comments that look like this:

```
-- Name: id; Type: DEFAULT
-- Name: users_pkey; Type: CONSTRAINT
```

Based on the previous regexes, it looks like the code assumed that at least with certain Postgres versions there's something before the name. But that's not the case for my version (9.5.4). Since I assume this is necessary for some Postgres versions, I've just made the offending part optional.