### PR TITLE
Don't require the line ends in a comma since the last one doesn't

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -30,9 +30,9 @@ module ActiveRecordCleanDbStructure
       # Reduce noise for id fields by making them SERIAL instead of integer+sequence stuff
       #
       # This is a bit optimistic, but works as long as you don't have an id field thats not a sequence/uuid
-      dump.gsub!(/^    id integer NOT NULL,$/, '    id SERIAL PRIMARY KEY,')
-      dump.gsub!(/^    id bigint NOT NULL,$/, '    id BIGSERIAL PRIMARY KEY,')
-      dump.gsub!(/^    id uuid DEFAULT uuid_generate_v4\(\) NOT NULL,$/, '    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,')
+      dump.gsub!(/^    id integer NOT NULL(,)?$/, '    id SERIAL PRIMARY KEY\1')
+      dump.gsub!(/^    id bigint NOT NULL(,)?$/, '    id BIGSERIAL PRIMARY KEY\1')
+      dump.gsub!(/^    id uuid DEFAULT uuid_generate_v4\(\) NOT NULL(,)?$/, '    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY\1')
       dump.gsub!(/^CREATE SEQUENCE \w+_id_seq\s+START WITH 1\s+INCREMENT BY 1\s+NO MINVALUE\s+NO MAXVALUE\s+CACHE 1;$/, '')
       dump.gsub!(/^ALTER SEQUENCE \w+_id_seq OWNED BY .*;$/, '')
       dump.gsub!(/^ALTER TABLE ONLY \w+ ALTER COLUMN id SET DEFAULT nextval\('\w+_id_seq'::regclass\);$/, '')


### PR DESCRIPTION
When I ran this, one of the lines that was supposed to be rewritten to be a `PRIMARY KEY` was missed because it was the last column listed in my table. The last column has no comma, and the regex matcher was expecting that it did.