### PR TITLE
Allow primary keys to be the last column of a table

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -30,9 +30,9 @@ module ActiveRecordCleanDbStructure
       # Reduce noise for id fields by making them SERIAL instead of integer+sequence stuff
       #
       # This is a bit optimistic, but works as long as you don't have an id field thats not a sequence/uuid
-      dump.gsub!(/^    id integer NOT NULL,$/, '    id SERIAL PRIMARY KEY,')
-      dump.gsub!(/^    id bigint NOT NULL,$/, '    id BIGSERIAL PRIMARY KEY,')
-      dump.gsub!(/^    id uuid DEFAULT uuid_generate_v4\(\) NOT NULL,$/, '    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,')
+      dump.gsub!(/^    id integer NOT NULL(,)?$/, '    id SERIAL PRIMARY KEY\1')
+      dump.gsub!(/^    id bigint NOT NULL(,)?$/, '    id BIGSERIAL PRIMARY KEY\1')
+      dump.gsub!(/^    id uuid DEFAULT uuid_generate_v4\(\) NOT NULL(,)?$/, '    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY\1')
       dump.gsub!(/^CREATE SEQUENCE \w+_id_seq\s+START WITH 1\s+INCREMENT BY 1\s+NO MINVALUE\s+NO MAXVALUE\s+CACHE 1;$/, '')
       dump.gsub!(/^ALTER SEQUENCE \w+_id_seq OWNED BY .*;$/, '')
       dump.gsub!(/^ALTER TABLE ONLY \w+ ALTER COLUMN id SET DEFAULT nextval\('\w+_id_seq'::regclass\);$/, '')


### PR DESCRIPTION
Use case: When adding a new column to a table, Postgres adds it to the end of the table definition. If the table has no further constraints, it's impossible to turn this new column into a primary key.

This change fixes the code for the use case so a comma after the primary key column isn't required.