### PR TITLE
Prefer File.open with block over File.write

### DIFF
--- a/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
+++ b/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
@@ -9,6 +9,8 @@ Rake::Task['db:structure:dump'].enhance do
   filenames.each do |filename|
     cleaner = ActiveRecordCleanDbStructure::CleanDump.new(File.read(filename))
     cleaner.run
-    File.write(filename, cleaner.dump)
+    File.open(filename, 'w') do |f|
+      f << cleaner.dump
+    end
   end
 end


### PR DESCRIPTION
Hi!

I debugged an issue with `db/structure.sql` this morning.

It was created on my CI machine, where migrations had run.

Permissions on `db/structure.sql` ended up `rw-------`, instead of the expected `rw-r--r--`.

This PR changes the `File.write` call to a `File.open` with a block, inside of which we write to the file. Would this preserve mode?