### PR TITLE
pg 10.x adds AS Integer to structure.sql format

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -34,7 +34,7 @@ module ActiveRecordCleanDbStructure
       dump.gsub!(/^    id bigint NOT NULL(,)?$/, '    id BIGSERIAL PRIMARY KEY\1')
       dump.gsub!(/^    id uuid DEFAULT uuid_generate_v4\(\) NOT NULL(,)?$/, '    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY\1')
       dump.gsub!(/^    id uuid DEFAULT gen_random_uuid\(\) NOT NULL(,)?$/, '    id uuid DEFAULT gen_random_uuid() PRIMARY KEY\1')
-      dump.gsub!(/^CREATE SEQUENCE \w+_id_seq\s+START WITH 1\s+INCREMENT BY 1\s+NO MINVALUE\s+NO MAXVALUE\s+CACHE 1;$/, '')
+      dump.gsub!(/^CREATE SEQUENCE \w+_id_seq\s+(AS integer\s+)?START WITH 1\s+INCREMENT BY 1\s+NO MINVALUE\s+NO MAXVALUE\s+CACHE 1;$/, '')
       dump.gsub!(/^ALTER SEQUENCE \w+_id_seq OWNED BY .*;$/, '')
       dump.gsub!(/^ALTER TABLE ONLY \w+ ALTER COLUMN id SET DEFAULT nextval\('\w+_id_seq'::regclass\);$/, '')
       dump.gsub!(/^ALTER TABLE ONLY \w+\s+ADD CONSTRAINT \w+_pkey PRIMARY KEY \(id\);$/, '')


### PR DESCRIPTION
This updates the regex to match the pg 10.x format which includes `AS integer` for sequences.

Should still be backwards compatible with 9.x which does not specify AS integer. 