### PR TITLE
Sort table column definitions alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ CREATE INDEX index_users_on_tentant_id ON public.users USING btree (tenant_id);
 CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
 ```
 
+To enable sorting the table column definitions alphabetically, discarding the actual order provided by `pg_dump`, set `order_column_definitions`:
+
+```ruby
+Rails.application.configure do
+  config.activerecord_clean_db_structure.order_column_definitions = true
+end
+```
+
 ## Authors
 
 * [Lukas Fittl](https://github.com/lfittl)

--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -108,10 +108,12 @@ module ActiveRecordCleanDbStructure
       # Reduce 2+ lines of whitespace to one line of whitespace
       dump.gsub!(/\n{2,}/m, "\n\n")
 
-      dump.replace(sort_table_columns(dump))
+      if options[:order_column_definitions] == true
+        dump.replace(order_column_definitions(dump))
+      end
     end
 
-    def sort_table_columns(source)
+    def order_column_definitions(source)
       result = []
 
       parse_column_name = ->(line) { line.match(/^    "?([^" ]+)/)[1] }


### PR DESCRIPTION
When developers simultaneously work on the tasks that require new columns in the database,
it's possible that their local databases will end up with columns being added in different order, leading to inconsistent database structure dumps.

By sorting the columns alphabetically we enforce the same order for everyone, keeping the file consistent.