### PR TITLE
Make cleaner configurable via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ Currently the library assumes all your `id` columns are either SERIAL, BIGSERIAL
 
 Multi-column primary keys, as well as tables that don't have `id` as the primary key are not supported right now, and might lead to wrong output.
 
-Patches and test cases welcome!
+You can disable this part of the _cleaning_ process in your `config/environments/<environment>.rb` (or `config/application.rb`):
+
+```ruby
+Rails.application.configure do
+  config.activerecord_clean_db_structure.ignore_ids = true
+end
+```
 
 ## Authors
 

--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -1,8 +1,10 @@
 module ActiveRecordCleanDbStructure
   class CleanDump
-    attr_reader :dump
-    def initialize(dump)
+    attr_reader :dump, :options
+
+    def initialize(dump, options = {})
       @dump = dump
+      @options = options
     end
 
     def run
@@ -33,20 +35,22 @@ module ActiveRecordCleanDbStructure
       # Remove useless comment lines
       dump.gsub!(/^--$/, '')
 
-      # Reduce noise for id fields by making them SERIAL instead of integer+sequence stuff
-      #
-      # This is a bit optimistic, but works as long as you don't have an id field thats not a sequence/uuid
-      dump.gsub!(/^    id integer NOT NULL(,)?$/, '    id SERIAL PRIMARY KEY\1')
-      dump.gsub!(/^    id bigint NOT NULL(,)?$/, '    id BIGSERIAL PRIMARY KEY\1')
-      dump.gsub!(/^    id uuid DEFAULT (public\.)?uuid_generate_v4\(\) NOT NULL(,)?$/, '    id uuid DEFAULT \1uuid_generate_v4() PRIMARY KEY\2')
-      dump.gsub!(/^    id uuid DEFAULT (public\.)?gen_random_uuid\(\) NOT NULL(,)?$/, '    id uuid DEFAULT \1gen_random_uuid() PRIMARY KEY\2')
-      dump.gsub!(/^CREATE SEQUENCE [\w\.]+_id_seq\s+(AS integer\s+)?START WITH 1\s+INCREMENT BY 1\s+NO MINVALUE\s+NO MAXVALUE\s+CACHE 1;$/, '')
-      dump.gsub!(/^ALTER SEQUENCE [\w\.]+_id_seq OWNED BY .*;$/, '')
-      dump.gsub!(/^ALTER TABLE ONLY [\w\.]+ ALTER COLUMN id SET DEFAULT nextval\('[\w\.]+_id_seq'::regclass\);$/, '')
-      dump.gsub!(/^ALTER TABLE ONLY [\w\.]+\s+ADD CONSTRAINT [\w\.]+_pkey PRIMARY KEY \(id\);$/, '')
-      dump.gsub!(/^-- Name: (\w+\s+)?id; Type: DEFAULT$/, '')
-      dump.gsub!(/^-- .*_id_seq; Type: SEQUENCE.*/, '')
-      dump.gsub!(/^-- Name: (\w+\s+)?\w+_pkey; Type: CONSTRAINT$/, '')
+      unless options[:ignore_ids] == true
+        # Reduce noise for id fields by making them SERIAL instead of integer+sequence stuff
+        #
+        # This is a bit optimistic, but works as long as you don't have an id field thats not a sequence/uuid
+        dump.gsub!(/^    id integer NOT NULL(,)?$/, '    id SERIAL PRIMARY KEY\1')
+        dump.gsub!(/^    id bigint NOT NULL(,)?$/, '    id BIGSERIAL PRIMARY KEY\1')
+        dump.gsub!(/^    id uuid DEFAULT (public\.)?uuid_generate_v4\(\) NOT NULL(,)?$/, '    id uuid DEFAULT \1uuid_generate_v4() PRIMARY KEY\2')
+        dump.gsub!(/^    id uuid DEFAULT (public\.)?gen_random_uuid\(\) NOT NULL(,)?$/, '    id uuid DEFAULT \1gen_random_uuid() PRIMARY KEY\2')
+        dump.gsub!(/^CREATE SEQUENCE [\w\.]+_id_seq\s+(AS integer\s+)?START WITH 1\s+INCREMENT BY 1\s+NO MINVALUE\s+NO MAXVALUE\s+CACHE 1;$/, '')
+        dump.gsub!(/^ALTER SEQUENCE [\w\.]+_id_seq OWNED BY .*;$/, '')
+        dump.gsub!(/^ALTER TABLE ONLY [\w\.]+ ALTER COLUMN id SET DEFAULT nextval\('[\w\.]+_id_seq'::regclass\);$/, '')
+        dump.gsub!(/^ALTER TABLE ONLY [\w\.]+\s+ADD CONSTRAINT [\w\.]+_pkey PRIMARY KEY \(id\);$/, '')
+        dump.gsub!(/^-- Name: (\w+\s+)?id; Type: DEFAULT$/, '')
+        dump.gsub!(/^-- .*_id_seq; Type: SEQUENCE.*/, '')
+        dump.gsub!(/^-- Name: (\w+\s+)?\w+_pkey; Type: CONSTRAINT$/, '')
+      end
 
       # Remove inherited tables
       inherited_tables_regexp = /-- Name: ([\w_\.]+); Type: TABLE\n\n[^;]+?INHERITS \([\w_\.]+\);/m

--- a/lib/activerecord-clean-db-structure/railtie.rb
+++ b/lib/activerecord-clean-db-structure/railtie.rb
@@ -1,5 +1,7 @@
 module ActiveRecordCleanDbStructure
   class Railtie < Rails::Railtie
+    config.activerecord_clean_db_structure = ActiveSupport::OrderedOptions.new
+
     rake_tasks do
       load 'activerecord-clean-db-structure/tasks/clean_db_structure.rake'
     end

--- a/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
+++ b/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
@@ -7,7 +7,10 @@ Rake::Task['db:structure:dump'].enhance do
   end
 
   filenames.each do |filename|
-    cleaner = ActiveRecordCleanDbStructure::CleanDump.new(File.read(filename))
+    cleaner = ActiveRecordCleanDbStructure::CleanDump.new(
+      File.read(filename),
+      **Rails.application.config.activerecord_clean_db_structure
+    )
     cleaner.run
     File.write(filename, cleaner.dump)
   end


### PR DESCRIPTION
This PR adds an ability to ignore _non-stable_ features (like non-`id` primary keys) while performing the cleaning.

Tested with Ruby 2.5.1, Rails 4.2.

P.S. Thanks for the gem, it's really helpful. 