### PR TITLE
Enhancement: put indexes immediately after respective tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add "indexes_after_tables" option to allow indexes to be placed following the respective tables
+
 ## 0.3.0    2019-05-07
 
 * Add "ignore_ids" option to allow disabling of primary key substitution logic [#12](https://github.com/lfittl/activerecord-clean-db-structure/pull/12) [Vladimir Dementyev](https://github.com/palkan)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,29 @@ Rails.application.configure do
 end
 ```
 
+## Other options
+
+You can optionally have indexes following the respective tables setting `indexes_after_tables`:
+
+```ruby
+Rails.application.configure do
+  config.activerecord_clean_db_structure.indexes_after_tables = true
+end
+```
+
+When it is enabled the structure looks like this:
+
+```sql
+CREATE TABLE public.users (
+    id SERIAL PRIMARY KEY,
+    tenant_id integer,
+    email text NOT NULL
+);
+
+CREATE INDEX index_users_on_tentant_id ON public.users USING btree (tenant_id);
+CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
+```
+
 ## Authors
 
 * [Lukas Fittl](https://github.com/lfittl)

--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -90,17 +90,19 @@ module ActiveRecordCleanDbStructure
       # Remove whitespace between schema migration INSERTS to make editing easier
       dump.gsub!(/^(INSERT INTO schema_migrations .*)\n\n/, "\\1\n")
 
-      # Extract indexes, remove comments and place indexes just after the respective tables
-      indexes =
-        dump
-          .scan(/^CREATE.+INDEX.+ON.+\n/)
-          .group_by { |line| line.scan(/\b\w+\.\w+\b/).first }
-          .transform_values(&:join)
+      if options[:indexes_after_tables] == true
+        # Extract indexes, remove comments and place them just after the respective tables
+        indexes =
+          dump
+            .scan(/^CREATE.+INDEX.+ON.+\n/)
+            .group_by { |line| line.scan(/\b\w+\.\w+\b/).first }
+            .transform_values(&:join)
 
-      dump.gsub!(/^CREATE( UNIQUE)? INDEX \w+ ON .+\n+/, '')
-      dump.gsub!(/^-- Name: \w+; Type: INDEX\n+/, '')
-      indexes.each do |table, indexes_for_table|
-        dump.gsub!(/^(CREATE TABLE #{table}\b(:?[^;\n]*\n)+\);\n)/) { $1 + "\n" + indexes_for_table }
+        dump.gsub!(/^CREATE( UNIQUE)? INDEX \w+ ON .+\n+/, '')
+        dump.gsub!(/^-- Name: \w+; Type: INDEX\n+/, '')
+        indexes.each do |table, indexes_for_table|
+          dump.gsub!(/^(CREATE TABLE #{table}\b(:?[^;\n]*\n)+\);\n)/) { $1 + "\n" + indexes_for_table }
+        end
       end
 
       # Reduce 2+ lines of whitespace to one line of whitespace


### PR DESCRIPTION
This patch puts the index statements just after the tables. That way it looks very similar to `db/schema.rb`:

```sql
CREATE TABLE public.users (
    id SERIAL PRIMARY KEY,
    email character varying DEFAULT ''::character varying NOT NULL,
    encrypted_password character varying DEFAULT ''::character varying NOT NULL,
    name character varying DEFAULT ''::character varying NOT NULL,
    tenant_id integer
);

CREATE INDEX index_users_on_tentant_id ON public.users USING btree (tenant_id);
CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
```