### PR TITLE
fix Rails 6 incompatibility

### DIFF
--- a/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
+++ b/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
@@ -5,7 +5,9 @@ Rake::Task['db:structure:dump'].enhance do
   filenames << ENV['DB_STRUCTURE'] if ENV.key?('DB_STRUCTURE')
 
   if ActiveRecord::VERSION::MAJOR >= 6
-    ActiveRecord::Tasks::DatabaseTasks.for_each do |spec_name|
+    # Based on https://github.com/rails/rails/pull/36560/files
+    databases = ActiveRecord::Tasks::DatabaseTasks.setup_initial_database_yaml
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
       Rails.application.config.paths['db'].each do |path|
         filenames << File.join(path, spec_name + '_structure.sql')
       end


### PR DESCRIPTION
This fixes an incompatibility with Rails 6 due to a [recent change](https://github.com/rails/rails/pull/36560/files) in a method signature:

```
rake aborted!
ArgumentError: wrong number of arguments (given 0, expected 1)
/usr/local/bundle/gems/activerecord-6.0.0/lib/active_record/tasks/database_tasks.rb:156:in `for_each'
/usr/local/bundle/bundler/gems/activerecord-clean-db-structure-0.3.0/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake:8:in `block in <main>'
```