### PR TITLE
Add ignored_tables for column reordering.

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -144,7 +144,7 @@ module ActiveRecordCleanDbStructure
       columns = []
 
       source.each_line do |source_line|
-        if source_line.start_with?("CREATE TABLE")
+        if source_line.start_with?("CREATE TABLE") && (source_line.split(' ') & (options[:ignored_tables] || [])).none?
           inside_table = true
           columns = []
           result << source_line


### PR DESCRIPTION
This adds the ability to ignore certain tables when doing column reordering.

Having this feature is particularly useful when there are Postgres DB functions (or other such things) that rely on implied column names from the ordering of the values in the query.

In particular, there is a case where a Postgres function in our project has an INSERT statement like this:
`INSERT INTO some_table VALUES(1, 'some_data', 2);`

The columns are implied from the ordering, so if the ordering changes, this breaks the assumption. In CircleCI, the `structure.sql` is used to initialize the test DB, so integrated testing fails with the new column ordering.