### PR TITLE
Consider constraints when sorting columns

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -138,13 +138,19 @@ module ActiveRecordCleanDbStructure
     private
 
     # Orders the columns definitions alphabetically
+    # - ignores quotes which surround column names that are equal to reserved PostgreSQL names.
     # - keeps the columns at the top and places the constraints at the bottom.
     def order_column_definitions
       dump.gsub!(/^(?<table>CREATE TABLE .+?\(\n)(?<columns>.+?)(?=\n\);$)/m) do
-        [
-          $~[:table],
-          $~[:columns].split(",\n").sort.partition { |column| !column.match?(/\A *CONSTRAINT/) }.flatten.join(",\n")
-        ].join
+        columns =
+          $~[:columns]
+          .split(",\n")
+          .sort_by { |column| column[/[^ "]+/] }
+          .partition { |column| !column.match?(/\A *CONSTRAINT/) }
+          .flatten
+          .join(",\n")
+
+        [$~[:table], columns].join
       end
     end
 

--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -127,6 +127,8 @@ module ActiveRecordCleanDbStructure
 
       # Reduce 2+ lines of whitespace to one line of whitespace
       dump.gsub!(/\n{2,}/m, "\n\n")
+      # End the file with a single end-of-line character
+      dump.sub!(/\n*\z/m, "\n")
 
       if options[:order_column_definitions] == true
         order_column_definitions

--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -142,6 +142,7 @@ module ActiveRecordCleanDbStructure
     # - keeps the columns at the top and places the constraints at the bottom.
     def order_column_definitions
       dump.gsub!(/^(?<table>CREATE TABLE .+?\(\n)(?<columns>.+?)(?=\n\);$)/m) do
+        table = $~[:table]
         columns =
           $~[:columns]
           .split(",\n")
@@ -150,7 +151,7 @@ module ActiveRecordCleanDbStructure
           .flatten
           .join(",\n")
 
-        [$~[:table], columns].join
+        [table, columns].join
       end
     end
 

--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -146,7 +146,7 @@ module ActiveRecordCleanDbStructure
         columns =
           $~[:columns]
           .split(",\n")
-          .sort_by { |column| column[/[^ "]+/] }
+          .sort_by { |column| column.delete('"') }
           .partition { |column| !column.match?(/\A *CONSTRAINT/) }
           .flatten
           .join(",\n")


### PR DESCRIPTION
The ordering of columns is a great option that we use for a while now. The current implementation however does not take table CONSTRAINTs into account. This results in all CONSTRAINTs to be placed in front of the columns definitions, which is not the PostgreSQL default. And it does not actually sort the CONSTRAINTs since it only sorts based on the first word of the statement.

This PR fixes both issues.

PS: most whitespace correction tools enforce files to end with a single end-of-line character by default. The dump always ends with 2. It is a small issue I also fixed here, but if you like I can place it in a separate PR.

Let me know what you think.