### PR TITLE
Split primary_keys and sequences cleanups

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -190,7 +190,7 @@ module ActiveRecordCleanDbStructure
 
       # Adds the PRIMARY KEY property to each column for which it's statement has just been removed.
       primary_keys.each do |table, column|
-        dump.gsub!(/^(?<statement>CREATE TABLE #{table} \(.*\s+#{column}\s+[^,]+)/) do
+        dump.gsub!(/^(?<statement>CREATE TABLE #{table} \(.*\s+#{column}\s+[^,\n]+)/) do
           "#{$LAST_MATCH_INFO[:statement].remove(/ NOT NULL\z/)} PRIMARY KEY"
         end
       end

--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -190,7 +190,7 @@ module ActiveRecordCleanDbStructure
 
       # Adds the PRIMARY KEY property to each column for which it's statement has just been removed.
       primary_keys.each do |table, column|
-        dump.gsub!(/^(?<statement>CREATE TABLE #{table} \(.*\s+#{column}\s+[^,\n]+)/) do
+        dump.gsub!(/^(?<statement>CREATE TABLE #{table} \(.*?\s+#{column}\s+[^,\n]+)/m) do
           "#{$LAST_MATCH_INFO[:statement].remove(/ NOT NULL\z/)} PRIMARY KEY"
         end
       end


### PR DESCRIPTION
I introduced a primary key into my schema with a `character varying` as datatype but still `id` as it's name. In order for this to work I had to disable the `ignore_ids` functionality, which is a shame since that functionality does a good job of cleaning up de sql file.

In order to make it work I separated the logic that handles primary keys from the logic that handles sequences. This allows to have a primary key with any datatype and any column name and still does the cleanup correctly. As a side benefit it now recognizes the primary key of the `ar_internal_metadata` table, which is named `key` instead of `id`.

There's still room for improvement on the sequences bit but that falls outside the scope of this PR.