### PR TITLE
Fix incorrect primary structure.sql filename in the case of multi-database setup

### DIFF
--- a/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
+++ b/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
@@ -9,7 +9,8 @@ Rake::Task['db:structure:dump'].enhance do
     databases = ActiveRecord::Tasks::DatabaseTasks.setup_initial_database_yaml
     ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
       Rails.application.config.paths['db'].each do |path|
-        filenames << File.join(path, spec_name + '_structure.sql')
+        filename = spec_name == 'primary' ? 'structure.sql' : spec_name + '_structure.sql'
+        filenames << File.join(path, filename)
       end
     end
   end


### PR DESCRIPTION
Hi there, we just introduced a secondary database to our Rails 6 app and were surprised to see `db:migrate` fail with this error:
```
Errno::ENOENT: No such file or directory @ rb_sysopen - db/primary_structure.sql
…/activerecord-clean-db-structure/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake:25:in `read'
```

Here's a little fix to get past this bummer.