### PR TITLE
Rails 6.1 compatibility: Hook into db:schema:dump, not db:structure:dump

### DIFF
--- a/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
+++ b/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
@@ -1,6 +1,6 @@
 require 'activerecord-clean-db-structure/clean_dump'
 
-Rake::Task['db:structure:dump'].enhance do
+Rake::Task['db:schema:dump'].enhance do
   filenames = []
   filenames << ENV['DB_STRUCTURE'] if ENV.key?('DB_STRUCTURE')
 


### PR DESCRIPTION
In Rails 6.1, running `rake db:structure:dump` prints a deprecation warning. The `db:migrate` task appears to invoke `db:schema:dump` instead. This change allows the cleanup to happen as expected when running migrations in Rails 6.1.

I'm not sure if I should add some code to detect the Rails version and hook into the older `db:structure:dump` on older versions or ?