### PR TITLE
Fix Rake task enhancement for compatibility with Rails 6.1+

### DIFF
--- a/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
+++ b/lib/activerecord-clean-db-structure/tasks/clean_db_structure.rake
@@ -1,6 +1,6 @@
 require 'activerecord-clean-db-structure/clean_dump'
 
-Rake::Task['db:structure:dump'].enhance do
+Rake::Task[ActiveRecord.version >= Gem::Version.new('6.1') ? 'db:schema:dump' : 'db:structure:dump'].enhance do
   filenames = []
   filenames << ENV['DB_STRUCTURE'] if ENV.key?('DB_STRUCTURE')
 


### PR DESCRIPTION
Rails 6.1 deprecated the `db:structure:dump` Rake task in favor of a combined `db:schema:dump` task: https://github.com/rails/rails/pull/39470 Even internally, tasks like `db:migrate` are now invoking `db:schema:dump` after the migration instead of switching between `db:{structure,schema}:dump` conditionally.

However, activerecord-clean-db-structure was hooking explicitly into the `db:structure:dump` task. This meant that your db/structure.sql would no longer be reformatted by the gem after upgrading to Rails 6.1+.

There was an existing pull request at https://github.com/lfittl/activerecord-clean-db-structure/pull/26 that just swapped the task name, but (a) that hasn't been merged in over a year and (b) it doesn't bother with a version check. The present commit improves upon the other PR by conditionally switching the task based on the version of the activerecord gem.