### PR TITLE
Improve performance for databases with many partitions

### DIFF
--- a/test/data/partitions.sql
+++ b/test/data/partitions.sql
@@ -10,17 +10,20 @@ CREATE TABLE public.autovacuum_run_stats_35d (
 )
 PARTITION BY RANGE (occurred_at);
 
+
 --
 -- Name: index_autovacuum_run_stats_35d_on_schema_table_id_occurred_at; Type: INDEX
 --
 
 CREATE INDEX index_autovacuum_run_stats_35d_on_schema_table_id_occurred_at ON public.autovacuum_run_stats_35d USING btree (schema_table_id, occurred_at);
 
+
 --
 -- Name: index_autovacuum_run_stats_35d_on_server_id_and_occurred_at; Type: INDEX
 --
 
 CREATE INDEX index_autovacuum_run_stats_35d_on_server_id_and_occurred_at ON public.autovacuum_run_stats_35d USING btree (server_id, occurred_at);
+
 
 --
 -- Name: autovacuum_run_stats_35d_20241026; Type: TABLE; Schema: public; Owner: -
@@ -33,11 +36,13 @@ CREATE TABLE public.autovacuum_run_stats_35d_20241026 (
     occurred_at timestamp with time zone NOT NULL
 );
 
+
 --
 -- Name: autovacuum_run_stats_35d_20241026; Type: TABLE ATTACH; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.autovacuum_run_stats_35d ATTACH PARTITION public.autovacuum_run_stats_35d_20241026 FOR VALUES FROM ('2024-10-25 19:00:00-05') TO ('2024-10-26 19:00:00-05');
+
 
 --
 -- Name: autovacuum_run_stats_35d_20241026 autovacuum_run_stats_35d_20241026_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -46,11 +51,13 @@ ALTER TABLE ONLY public.autovacuum_run_stats_35d ATTACH PARTITION public.autovac
 ALTER TABLE ONLY public.autovacuum_run_stats_35d_20241026
     ADD CONSTRAINT autovacuum_run_stats_35d_20241026_pkey PRIMARY KEY (autovacuum_run_stats_id);
 
+
 --
 -- Name: autovacuum_run_stats_35d_20241026_server_id_occurred_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX autovacuum_run_stats_35d_20241026_server_id_occurred_at_idx ON public.autovacuum_run_stats_35d_20241026 USING btree (server_id, occurred_at);
+
 
 --
 -- Name: autovacuum_run_stats_35d_2024_schema_table_id_occurred_at_idx25; Type: INDEX; Schema: public; Owner: -
@@ -58,11 +65,13 @@ CREATE INDEX autovacuum_run_stats_35d_20241026_server_id_occurred_at_idx ON publ
 
 CREATE INDEX autovacuum_run_stats_35d_2024_schema_table_id_occurred_at_idx25 ON public.autovacuum_run_stats_35d_20241026 USING btree (schema_table_id, occurred_at);
 
+
 --
 -- Name: autovacuum_run_stats_35d_20241026_server_id_occurred_at_idx; Type: INDEX ATTACH; Schema: public; Owner: -
 --
 
 ALTER INDEX public.index_autovacuum_run_stats_35d_on_server_id_and_occurred_at ATTACH PARTITION public.autovacuum_run_stats_35d_20241026_server_id_occurred_at_idx;
+
 
 --
 -- Name: schema_table_infos_35d; Type: TABLE; Schema: public; Owner: -
@@ -76,8 +85,13 @@ CREATE TABLE public.schema_table_infos_35d (
 PARTITION BY RANGE (collected_at);
 
 
+--
+-- Name: schema_table_infos_35d schema_table_infos_35d_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.schema_table_infos_35d
     ADD CONSTRAINT schema_table_infos_35d_pkey PRIMARY KEY (schema_table_id, collected_at);
+
 
 --
 -- Name: schema_table_infos_35d_20240920; Type: TABLE; Schema: public; Owner: -
@@ -89,11 +103,13 @@ CREATE TABLE public.schema_table_infos_35d_20240920 (
     server_id uuid NOT NULL
 );
 
+
 --
 -- Name: schema_table_infos_35d_20240920; Type: TABLE ATTACH; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.schema_table_infos_35d ATTACH PARTITION public.schema_table_infos_35d_20240920 FOR VALUES FROM ('2024-09-19 19:00:00-05') TO ('2024-09-20 19:00:00-05');
+
 
 --
 -- Name: schema_table_infos_35d_20240920 schema_table_infos_35d_20240920_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -102,17 +118,20 @@ ALTER TABLE ONLY public.schema_table_infos_35d ATTACH PARTITION public.schema_ta
 ALTER TABLE ONLY public.schema_table_infos_35d_20240920
     ADD CONSTRAINT schema_table_infos_35d_20240920_pkey PRIMARY KEY (schema_table_id, collected_at);
 
+
 --
 -- Name: schema_table_infos_35d_20240920_server_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX schema_table_infos_35d_20240920_server_id_idx ON public.schema_table_infos_35d_20240920 USING btree (server_id);
 
+
 --
 -- Name: schema_table_infos_35d_2024092_schema_table_id_collected_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX schema_table_infos_35d_2024092_schema_table_id_collected_at_idx ON public.schema_table_infos_35d_20240920 USING btree (schema_table_id, collected_at DESC);
+
 
 --
 -- Name: schema_table_infos_35d_20240920_pkey; Type: INDEX ATTACH; Schema: public; Owner: -

--- a/test/expectations/partitions.sql
+++ b/test/expectations/partitions.sql
@@ -28,4 +28,3 @@ PARTITION BY RANGE (collected_at);
 
 ALTER TABLE ONLY public.schema_table_infos_35d
     ADD CONSTRAINT schema_table_infos_35d_pkey PRIMARY KEY (schema_table_id, collected_at);
-


### PR DESCRIPTION
This is built on top of #52.

Our database has many partitions, causing `time rails db:structure:dump` to take 5.9 seconds. The changes in this PR get it down to 1.8 seconds (compared to 1.3 seconds without this gem).

This implementation combines a comment and its associated statement into a single string, and builds an array of those comment+statement pairs. Then it drops any array elements that contain a reference to a partition table or index. Combining the comment and statement was a necessary performance optimization, to reduce the number of elements being iterated over and then removed.

<details><summary>I also tried some approaches using pg_query, but struggled to get the test suite to pass</summary>

```rb
# Build strings for statements until the next comment is reached
strings = []
start = nil
PgQuery.scan(dump).first.tokens.each do |token|
  if token.token == :SQL_COMMENT
    if start != nil
      strings << dump[start..token.start-1]
      start = nil
    end
    strings << dump[token.start..token.end]
  elsif start == nil
    start = token.start
  end
end
if start != nil
  strings << dump[start..]
end

# Combine comments with statements until a semicolon is reached
strings = []
start = nil
PgQuery.scan(dump).first.tokens.each do |token|
  if token.token == :ASCII_59
    strings << dump[start..token.end]
    start = nil
  else
    start ||= token.start
  end
end
if start != nil
  strings << dump[start..]
end