### PR TITLE
Clean `SET transaction_timeout = 0;` (introduced by Postgres 17)

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -24,6 +24,7 @@ module ActiveRecordCleanDbStructure
       dump.gsub!(/^-- Dumped.*/, '')
       dump.gsub!(/^SET row_security = off;\n/m, '') # 9.5
       dump.gsub!(/^SET idle_in_transaction_session_timeout = 0;\n/m, '') # 9.6
+      dump.gsub!(/^SET transaction_timeout = 0;\n/m, '') # 17
       dump.gsub!(/^SET default_with_oids = false;\n/m, '') # all older than 12
       dump.gsub!(/^SET xmloption = content;\n/m, '') # 12
       dump.gsub!(/^SET default_table_access_method = heap;\n/m, '') # 12

--- a/test/data/input.sql
+++ b/test/data/input.sql
@@ -1,6 +1,7 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);


### PR DESCRIPTION
This PR cleans a line `SET transaction_timeout = 0;`.

This was [introduced by PostgreSQL 17](https://www.postgresql.org/docs/current/release-17.html), but is not understood by older servers.
