### PR TITLE
Clean \restrict and \unrestrict directives (introduced in Postgres 17.6)

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -30,6 +30,7 @@ module ActiveRecordCleanDbStructure
       dump.gsub!(/^SET default_with_oids = false;\n/m, '') # all older than 12
       dump.gsub!(/^SET xmloption = content;\n/m, '') # 12
       dump.gsub!(/^SET default_table_access_method = heap;\n/m, '') # 12
+      dump.gsub!(/^\\(un)?restrict [A-Za-z0-9]+\n\n?/m, '') # 17.6
 
       extensions_to_remove = ["pg_stat_statements", "pg_buffercache"]
       if options[:keep_extensions] == :all

--- a/test/data/input.sql
+++ b/test/data/input.sql
@@ -1,3 +1,5 @@
+\restrict eVA4gCZvdSnhJn7MKha0lZbmA4
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -148,6 +150,8 @@ CREATE INDEX index_delayed_jobs_on_run_at ON public.delayed_jobs USING btree (ru
 --
 
 SET search_path TO "$user", public;
+
+\unrestrict eVA4gCZvdSnhJn7MKha0lZbmA4
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20240822225012'),


### PR DESCRIPTION
This change removes `\restrict` and `\unrestrict` markers that were [added in PG 17.6](https://www.postgresql.org/docs/release/17.6/).

