### PR TITLE
Index names may be quoted in some circumstances

### DIFF
--- a/test/data/input.sql
+++ b/test/data/input.sql
@@ -137,6 +137,12 @@ CREATE INDEX index_delayed_jobs_on_locked_by ON public.delayed_jobs USING btree 
 
 CREATE INDEX index_delayed_jobs_on_queue ON public.delayed_jobs USING btree (queue);
 
+--
+-- Name: index_delayed_jobs_on_failed_at_IS_NULL; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "index_delayed_jobs_on_failed_at_IS_NULL" ON public.delayed_jobs USING btree (((failed_at IS NULL)));
+
 
 --
 -- Name: index_delayed_jobs_on_run_at; Type: INDEX; Schema: public; Owner: -

--- a/test/expectations/default_props.sql
+++ b/test/expectations/default_props.sql
@@ -57,6 +57,10 @@ CREATE INDEX index_delayed_jobs_on_locked_by ON public.delayed_jobs USING btree 
 
 CREATE INDEX index_delayed_jobs_on_queue ON public.delayed_jobs USING btree (queue);
 
+-- Name: index_delayed_jobs_on_failed_at_IS_NULL; Type: INDEX
+
+CREATE INDEX "index_delayed_jobs_on_failed_at_IS_NULL" ON public.delayed_jobs USING btree (((failed_at IS NULL)));
+
 -- Name: index_delayed_jobs_on_run_at; Type: INDEX
 
 CREATE INDEX index_delayed_jobs_on_run_at ON public.delayed_jobs USING btree (run_at) WHERE (locked_at IS NULL);

--- a/test/expectations/ignore_ids.sql
+++ b/test/expectations/ignore_ids.sql
@@ -83,6 +83,10 @@ CREATE INDEX index_delayed_jobs_on_locked_by ON public.delayed_jobs USING btree 
 
 CREATE INDEX index_delayed_jobs_on_queue ON public.delayed_jobs USING btree (queue);
 
+-- Name: index_delayed_jobs_on_failed_at_IS_NULL; Type: INDEX
+
+CREATE INDEX "index_delayed_jobs_on_failed_at_IS_NULL" ON public.delayed_jobs USING btree (((failed_at IS NULL)));
+
 -- Name: index_delayed_jobs_on_run_at; Type: INDEX
 
 CREATE INDEX index_delayed_jobs_on_run_at ON public.delayed_jobs USING btree (run_at) WHERE (locked_at IS NULL);

--- a/test/expectations/indexes_after_tables.sql
+++ b/test/expectations/indexes_after_tables.sql
@@ -39,6 +39,7 @@ WITH (fillfactor='85');
 
 CREATE INDEX index_delayed_jobs_on_locked_by ON public.delayed_jobs USING btree (locked_by);
 CREATE INDEX index_delayed_jobs_on_queue ON public.delayed_jobs USING btree (queue);
+CREATE INDEX "index_delayed_jobs_on_failed_at_IS_NULL" ON public.delayed_jobs USING btree (((failed_at IS NULL)));
 CREATE INDEX index_delayed_jobs_on_run_at ON public.delayed_jobs USING btree (run_at) WHERE (locked_at IS NULL);
 
 -- Name: schema_migrations; Type: TABLE

--- a/test/expectations/keep_extensions_all.sql
+++ b/test/expectations/keep_extensions_all.sql
@@ -63,6 +63,10 @@ CREATE INDEX index_delayed_jobs_on_locked_by ON public.delayed_jobs USING btree 
 
 CREATE INDEX index_delayed_jobs_on_queue ON public.delayed_jobs USING btree (queue);
 
+-- Name: index_delayed_jobs_on_failed_at_IS_NULL; Type: INDEX
+
+CREATE INDEX "index_delayed_jobs_on_failed_at_IS_NULL" ON public.delayed_jobs USING btree (((failed_at IS NULL)));
+
 -- Name: index_delayed_jobs_on_run_at; Type: INDEX
 
 CREATE INDEX index_delayed_jobs_on_run_at ON public.delayed_jobs USING btree (run_at) WHERE (locked_at IS NULL);

--- a/test/expectations/order_column_definitions.sql
+++ b/test/expectations/order_column_definitions.sql
@@ -57,6 +57,10 @@ CREATE INDEX index_delayed_jobs_on_locked_by ON public.delayed_jobs USING btree 
 
 CREATE INDEX index_delayed_jobs_on_queue ON public.delayed_jobs USING btree (queue);
 
+-- Name: index_delayed_jobs_on_failed_at_IS_NULL; Type: INDEX
+
+CREATE INDEX "index_delayed_jobs_on_failed_at_IS_NULL" ON public.delayed_jobs USING btree (((failed_at IS NULL)));
+
 -- Name: index_delayed_jobs_on_run_at; Type: INDEX
 
 CREATE INDEX index_delayed_jobs_on_run_at ON public.delayed_jobs USING btree (run_at) WHERE (locked_at IS NULL);

--- a/test/expectations/order_schema_migrations_values.sql
+++ b/test/expectations/order_schema_migrations_values.sql
@@ -57,6 +57,10 @@ CREATE INDEX index_delayed_jobs_on_locked_by ON public.delayed_jobs USING btree 
 
 CREATE INDEX index_delayed_jobs_on_queue ON public.delayed_jobs USING btree (queue);
 
+-- Name: index_delayed_jobs_on_failed_at_IS_NULL; Type: INDEX
+
+CREATE INDEX "index_delayed_jobs_on_failed_at_IS_NULL" ON public.delayed_jobs USING btree (((failed_at IS NULL)));
+
 -- Name: index_delayed_jobs_on_run_at; Type: INDEX
 
 CREATE INDEX index_delayed_jobs_on_run_at ON public.delayed_jobs USING btree (run_at) WHERE (locked_at IS NULL);


### PR DESCRIPTION
Index names can be wrapped in quotes in some circumstances, which breaks some index cleanup/relocation when cleaning the dump file.

This can happen when index names are selected manually, or when using rails' default index name generation when index fields containing SQL with a mix of case, ex:

```ruby
add_index :my_table, 'name', '(deleted_at IS NULL)'
```

would create a raw dump with

```
--
-- Name: index_my_table_on_nam_and_deleted_at_IS_NULL; Type: INDEX
--

CREATE INDEX "index_my_table_on_name_and_deleted_at_IS_NULL" ON public.my_table USING btree (name, ((deleted_at IS NULL));
```
