### PR TITLE
Fix leading newlines after removing 'dumped by' and `restrict` lines

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -30,7 +30,7 @@ module ActiveRecordCleanDbStructure
       dump.gsub!(/^SET default_with_oids = false;\n/m, '') # all older than 12
       dump.gsub!(/^SET xmloption = content;\n/m, '') # 12
       dump.gsub!(/^SET default_table_access_method = heap;\n/m, '') # 12
-      dump.gsub!(/^\\(un)?restrict [A-Za-z0-9]+\n\n?/m, '') # 17.6
+      dump.gsub!(/^\\(un)?restrict [A-Za-z0-9]+\n+/m, '') # 17.6
 
       extensions_to_remove = ["pg_stat_statements", "pg_buffercache"]
       if options[:keep_extensions] == :all

--- a/test/data/input.sql
+++ b/test/data/input.sql
@@ -1,5 +1,8 @@
 \restrict eVA4gCZvdSnhJn7MKha0lZbmA4
 
+-- Dumped from database version 17.4
+-- Dumped by pg_dump version 17.6
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;


### PR DESCRIPTION
If an SQL dump contains both `dumped from/by` comments and `\restrict`, the comments and double newlines are both removed _before_ `\restrict` is removed, so this input:

```
\restrict eVA4gCZvdSnhJn7MKha0lZbmA4

-- Dumped from database version 17.4
-- Dumped by pg_dump version 17.6

SET statement_timeout = 0;
SET lock_timeout = 0;
SET idle_in_transaction_session_timeout = 0;
```

becomes:

```


SET statement_timeout = 0;
SET lock_timeout = 0;
SET idle_in_transaction_session_timeout = 0;
```
 after cleanup.

To fix this, I'm trimming all newlines that follow the restrict, instead of limiting the replacement to 2 newline.